### PR TITLE
Setup basic 2-node conf

### DIFF
--- a/configs/spaceapps/README.md
+++ b/configs/spaceapps/README.md
@@ -1,0 +1,50 @@
+# Setup
+Run
+
+ - ionstart -I tcp.1.rc
+
+which calls `ionadmin`, `bpadmin` and `ipadmin` to perform the setup.
+
+# Testing
+
+> :whale: The assumption is made that these cases are tested with the
+> [Docker compose](docker-compose.yml) setup which may be started with
+> `docker-compose up`.
+
+Start a shell session inside node 1, using
+
+```
+docker-compose exec node-1 /bin/bash
+```
+
+and use [`bpecho`](bp/test/bping.c) as follows:
+
+
+```
+bpecho ipn:1.1
+```
+
+to initiate a receiver for bundles on endpoint `ipn:1.1`.
+
+> NOTE: Without first defining a listener (e.g.: `bpecho`) any connection
+> attempt (e.g.: `bping`) will fail.
+
+
+In order to confirm the existence of a connection, start a shell session in
+node 2 using
+
+```
+docker-compose exec node-2 /bin/bash
+```
+
+and issue pings with [`bping`](bp/test/bping.c) by running
+
+```
+bping -c 10 -v ipn:2.1 ipn:1.1
+```
+
+which will ping from `ipn:2.1` to `ipn1.1`.
+
+> NOTE: The source EID can be any valid EID that has been associated to the
+> current node, so from node 2 we can ping from EID's `ipn:2.1`, `ipn:2.2` and
+> `ipn:2.3`, but not from any of the `ipn:1.*` EID's.

--- a/configs/spaceapps/tcp.1.rc
+++ b/configs/spaceapps/tcp.1.rc
@@ -1,0 +1,53 @@
+## begin ionadmin 
+
+1 1 ''
+
+s
+
+a contact +1 +3600 1 1 100000
+
+a contact +1 +3600 1 2 100000
+a contact +1 +3600 2 1 100000
+a contact +1 +3600 2 2 100000
+
+a range +1 +3600 1 1 1
+
+a range +1 +3600 2 2 1
+a range +1 +3600 2 1 1
+
+m production 1000000
+m consumption 1000000
+
+## end ionadmin 
+
+
+## begin bpadmin 
+
+1
+
+a scheme ipn 'ipnfw' 'ipnadminep'
+
+a endpoint ipn:1.1 q
+a endpoint ipn:1.2 q
+a endpoint ipn:1.3 q
+
+a protocol stcp 1400 100
+
+a induct stcp 10.1.1.2:4556 stcpcli
+
+a outduct stcp 10.1.1.2:4556 stcpclo
+a outduct stcp 10.1.1.3:4556 stcpclo
+
+s
+
+## end bpadmin 
+
+
+## begin ipnadmin 
+
+a plan 1 stcp/10.1.1.2:4556
+a plan 2 stcp/10.1.1.3:4556
+
+## end ipnadmin 
+
+# EOF

--- a/configs/spaceapps/tcp.2.rc
+++ b/configs/spaceapps/tcp.2.rc
@@ -1,0 +1,53 @@
+## begin ionadmin 
+
+1 2 ''
+
+s
+
+a contact +1 +3600 1 1 100000
+
+a contact +1 +3600 1 2 100000
+a contact +1 +3600 2 1 100000
+a contact +1 +3600 2 2 100000
+
+a range +1 +3600 1 1 1
+
+a range +1 +3600 2 2 1
+a range +1 +3600 2 1 1
+
+m production 1000000
+m consumption 1000000
+
+## end ionadmin 
+
+
+## begin bpadmin 
+
+1
+
+a scheme ipn 'ipnfw' 'ipnadminep'
+
+a endpoint ipn:2.1 q
+a endpoint ipn:2.2 q
+a endpoint ipn:2.3 q
+
+a protocol stcp 1400 100
+
+a induct stcp 10.1.1.3:4556 stcpcli
+
+a outduct stcp 10.1.1.3:4556 stcpclo
+a outduct stcp 10.1.1.2:4556 stcpclo
+
+s
+
+## end bpadmin 
+
+
+## begin ipnadmin 
+
+a plan 2 stcp/10.1.1.3:4556
+a plan 1 stcp/10.1.1.2:4556
+
+## end ipnadmin 
+
+# EOF

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,9 @@ services:
     image: ion-dtn:latest
     volumes:
       - $PWD/docker_resources:/resources:ro
-    command: /resources/entrypoint.sh
+      - $PWD/configs/spaceapps:/tmp/configs:ro
+    command: |
+      bash -c "ln -s /dev/stdout ion.log & ionstart -I /tmp/configs/tcp.1.rc & tail -f /dev/null & wait"
     networks:
       default:
       ion_net:
@@ -16,7 +18,9 @@ services:
     image: ion-dtn:latest
     volumes:
       - $PWD/docker_resources:/resources:ro
-    command: /resources/entrypoint.sh
+      - $PWD/configs/spaceapps:/tmp/configs:ro
+    command: |
+      bash -c "ln -s /dev/stdout ion.log & ionstart -I /tmp/configs/tcp.2.rc & tail -f /dev/null & wait"
     networks:
       default:
       ion_net:


### PR DESCRIPTION
After `docker-compose up` a setup is spawned with two nodes that can actually reach each other if a listerer is defined. See the `configs/spaceapps/README.md` for more info.